### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ tf_chef_delivery_build CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_delivery_build Terraform plan.
 
+v0.3.2 (2016-04-25)
+-------------------
+- [Brian Menges] - Update name on `aws_security_group.delivery-build` for less conflicts in repeated use
+
 v0.3.1 (2016-04-25)
 -------------------
 - [Brian Menges] - Remove delivery-cli customization in `attributes-json.tpl`

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 # Delivery Build AWS security group - https://github.com/chef-cookbooks/delivery-cluster
 resource "aws_security_group" "delivery-build" {
-  name        = "delivery-build security group"
-  description = "Delivery Build security group"
+  name        = "${var.basename}-xx.${var.domain} security group"
+  description = "Delivery Build ${var.basename}-xx.${var.domain}"
   vpc_id      = "${var.aws_vpc_id}"
   tags        = {
-    Name      = "Delivery Build security group"
+    Name      = "${var.basename}-xx.${var.domain} security group"
   }
 }
 # SSH from Delivery


### PR DESCRIPTION
- [Brian Menges] - Update name on `aws_security_group.delivery-build` for less conflicts in repeated use
